### PR TITLE
Fix substatus to handle "Subscribed" response correctly

### DIFF
--- a/src/class-sendy-php-api.php
+++ b/src/class-sendy-php-api.php
@@ -236,6 +236,7 @@ if ( ! class_exists( 'Sendy_PHP_API' ) ) {
 			// Handle the results.
 			switch ( $result ) {
 				case 'Subscribed!':
+				case 'Subscribed':
 				case 'Unsubscribed':
 				case 'Unconfirmed':
 				case 'Bounced':


### PR DESCRIPTION
The substatus method was looking for a "Subscribed!" response from the Sendy API, but not "Subscribed" (without the exclamation mark on the end), so was returning false for existing subscribers. Not sure if this is due to an API change, so I've left both checks in.