### PR TITLE
Import Exception Class

### DIFF
--- a/src/Sendy.php
+++ b/src/Sendy.php
@@ -12,7 +12,7 @@
 namespace SENDY;
 
 use Requests;
-
+use Exception;
 
 // Helps with the CORS issues.
 header( 'Access-Control-Allow-Origin: *' );


### PR DESCRIPTION
When importing via composer, Exception is outside of the namespace of Sendy, so it needs to imported or "throw new \Exception" needs to be used instead.